### PR TITLE
Fix typo in template name in 2.9

### DIFF
--- a/app/templates/pages/docs/2.9.md
+++ b/app/templates/pages/docs/2.9.md
@@ -1217,7 +1217,7 @@ You need an other template design or more HTML5/CSS3 features? Then write us an 
 **7. <a id="7"></a>Customizing phpMyFAQ**
 
 phpMyFAQ users have even more customization opportunities. The key feature is the user selectable template sets, there 
-is a templates/default directory where the default layouts get shipped.
+is a template/default directory where the default layouts get shipped.
 
 [back to top][64]
 
@@ -1227,8 +1227,8 @@ is a templates/default directory where the default layouts get shipped.
 
 Follow these steps to create a custom template set:
 
-*   copy the directory assets/templates/default to assets/templates/example
-*   adjust template files in assets/templates/example to fit your needs
+*   copy the directory assets/template/default to assets/template/example
+*   adjust template files in assets/template/example to fit your needs
 *   activate "example" within Admin->Config->Main
 
 **Note:** There is a magic variable *{tplSetName}* containing the name of the actual layout available in each template 


### PR DESCRIPTION
The folder named "template" was misspelled as plural. 